### PR TITLE
Move range LP rewards to 72-bit arithmetic

### DIFF
--- a/contracts/interfaces/ICrocLpConduit.sol
+++ b/contracts/interfaces/ICrocLpConduit.sol
@@ -30,9 +30,9 @@ interface ICrocLpConduit {
      *           deposit. Reverts the transaction. */
     function depositCrocLiq (address sender, bytes32 poolHash,
                              int24 lowerTick, int24 upperTick,
-                             uint128 liq, uint64 mileage) external returns (bool);
+                             uint128 liq, uint72 mileage) external returns (bool);
 
     function withdrawCrocLiq (address sender, bytes32 poolHash,
                               int24 lowerTick, int24 upperTick,
-                              uint128 liq, uint64 mileage) external returns (bool);
+                              uint128 liq, uint72 mileage) external returns (bool);
 }

--- a/contracts/lens/CrocQuery.sol
+++ b/contracts/lens/CrocQuery.sol
@@ -309,7 +309,7 @@ contract CrocQuery {
                              uint32 timestamp, bool atomic) {
         bytes32 poolHash = PoolSpecs.encodeKey(base, quote, poolIdx);
         bytes32 posKey = keccak256(abi.encodePacked(owner, poolHash, lowerTick, upperTick));
-        bytes32 slot = keccak256(abi.encodePacked(posKey, CrocSlots.POS_MAP_SLOT));
+        bytes32 slot = keccak256(abi.encodePacked(posKey, CrocSlots.POS_MAP_SLOT_72));
         uint256 val = CrocSwapDex(dex_).readSlot(uint256(slot));
 
         liq = uint128((val << 128) >> 128);
@@ -367,13 +367,13 @@ contract CrocQuery {
         uint64 feeUpper = upperTick <= curveTick ? askFee : curveFee - askFee;
             
         unchecked {
-            uint64 odometer = feeUpper - feeLower;
+            uint72 odometer = uint72(type(uint64).max) + uint72(feeUpper) - uint72(feeLower);
 
             if (odometer < feeStart) {
                 return (0, 0, 0);
             }
 
-            uint64 accumFees = odometer - feeStart;
+            uint64 accumFees = uint64(odometer - feeStart);
             uint128 seeds = FixedPoint.mulQ48(liq, accumFees).toUint128By144();
             return convertSeedsToLiq(curve, seeds);
         }

--- a/contracts/mixins/LevelBook.sol
+++ b/contracts/mixins/LevelBook.sol
@@ -116,6 +116,22 @@ contract LevelBook is TickCensus {
         feeOdometer = clockFeeOdometer(poolIdx, midTick, bidTick, askTick, feeGlobal);
     }
 
+    /* @dev Near identical to addBookLiq() above but uses higher precision 72-bit 
+     *      range positions and fee odometer values. */
+    function addBookLiq72 (bytes32 poolIdx, int24 midTick, int24 bidTick, int24 askTick,
+                           uint96 lots, uint64 feeGlobal)
+        internal returns (uint72 feeOdometer) {
+
+        // Make sure to init before add, because init logic relies on pre-add liquidity
+        initLevel(poolIdx, midTick, bidTick, feeGlobal);
+        initLevel(poolIdx, midTick, askTick, feeGlobal);
+
+        addBid(poolIdx, bidTick, lots);
+        addAsk(poolIdx, askTick, lots);
+        feeOdometer = clockFeeOdometer72(poolIdx, midTick, bidTick, askTick, feeGlobal);
+    }
+
+
     /* @notice Call when removing liquidity associated with a specific range order.
      *         Decrements the associated tick levels as necessary.
      *
@@ -139,6 +155,19 @@ contract LevelBook is TickCensus {
         bool deleteBid = removeBid(poolIdx, bidTick, lots);
         bool deleteAsk = removeAsk(poolIdx, askTick, lots);
         feeOdometer = clockFeeOdometer(poolIdx, midTick, bidTick, askTick, feeGlobal);
+
+        if (deleteBid) { deleteLevel(poolIdx, bidTick); }
+        if (deleteAsk) { deleteLevel(poolIdx, askTick); }
+    }
+
+    /* @dev Near identical to removeBookLiq() above but uses higher precision 72-bit 
+     *      range positions and fee odometer values. */
+    function removeBookLiq72 (bytes32 poolIdx, int24 midTick, int24 bidTick, int24 askTick,
+                              uint96 lots, uint64 feeGlobal)
+        internal returns (uint72 feeOdometer) {
+        bool deleteBid = removeBid(poolIdx, bidTick, lots);
+        bool deleteAsk = removeAsk(poolIdx, askTick, lots);
+        feeOdometer = clockFeeOdometer72(poolIdx, midTick, bidTick, askTick, feeGlobal);
 
         if (deleteBid) { deleteLevel(poolIdx, bidTick); }
         if (deleteAsk) { deleteLevel(poolIdx, askTick); }
@@ -244,6 +273,26 @@ contract LevelBook is TickCensus {
         unchecked {
             return feeUpper - feeLower;
         }
+    }
+
+    /* @notice Snapshots a value cumulative fee accumulation in a tick range to be
+     *         used when calculating the growth of a position over time. See description
+     *         in clockFeeOdomter() for more details.
+     *
+     * @dev  Unlike clockFeeOdomter() the returned snapshot is a 72-bit representation.
+     *       Each snapshot adds a uint64 max offset to avoid the possibility of underflow. 
+     *       Because the offset is included on every calculation, it will always cancel out
+     *       in the rewards delta calculation. */
+    function clockFeeOdometer72 (bytes32 poolIdx, int24 currentTick,
+                                 int24 lowerTick, int24 upperTick, uint64 feeGlobal)
+        internal view returns (uint72) {
+        uint72 feeLower = pivotFeeBelow(poolIdx, lowerTick, currentTick, feeGlobal);
+        uint72 feeUpper = pivotFeeBelow(poolIdx, upperTick, currentTick, feeGlobal);
+        
+        // Set to be large enough, so the delta between the uint64 values from pivotFeeBelow()
+        // will never underflow the snapshot.
+        uint72 fixedOffset = type(uint64).max;
+        return (fixedOffset + feeUpper) - feeLower;
     }
 
     /* @dev Internally we checkpoint the last global accumulator value from the last

--- a/contracts/mixins/PoolRegistry.sol
+++ b/contracts/mixins/PoolRegistry.sol
@@ -190,10 +190,6 @@ contract PoolRegistry is StorageLayout {
 
     }
 
-    // Since take rate is represented in 1/256, this represents a maximum possible take 
-    // rate of 50%.
-    uint8 MAX_TAKE_RATE = 128;
-
     function setProtocolTakeRate (uint8 takeRate) internal {
         require(takeRate <= MAX_TAKE_RATE, "TR");
         protocolTakeRate_ = takeRate;

--- a/contracts/mixins/StorageLayout.sol
+++ b/contracts/mixins/StorageLayout.sol
@@ -114,6 +114,13 @@ contract StorageLayout {
         bool atomicLiq_;
     }
 
+    struct RangePosition72 {
+        uint128 liquidity_;
+        uint72 feeMileage_;
+        uint32 timestamp_;
+        bool atomicLiq_;
+    }
+
     struct AmbientPosition {
         uint128 seeds_;
         uint32 timestamp_;
@@ -148,6 +155,12 @@ contract StorageLayout {
 
     address treasury_;
     uint64 treasuryStartTime_;
+
+    // Since take rate is represented in 1/256, this represents a maximum possible take 
+    // rate of 50%.
+    uint8 MAX_TAKE_RATE = 128;
+
+    mapping(bytes32 => RangePosition72) internal positions72_;
 }
 
 /* @notice Contains the storage or storage hash offsets of the fields and sidecars
@@ -171,6 +184,7 @@ library CrocSlots {
     uint constant public AMB_MAP_SLOT = 65550;
     uint constant public CURVE_MAP_SLOT = 65551;
     uint constant public BAL_MAP_SLOT = 65552;
+    uint constant public POS_MAP_SLOT_72 = 65554;
 
         
     // The slots of the currently attached sidecar proxy contracts. These are set by
@@ -179,14 +193,21 @@ library CrocSlots {
     // a pre-existing proxy sidecar.
     uint16 constant BOOT_PROXY_IDX = 0;
     uint16 constant SWAP_PROXY_IDX = 1;
-    uint16 constant LP_PROXY_IDX = 2;
+    uint16 constant LP_PROXY_IDX = 128;
     uint16 constant COLD_PROXY_IDX = 3;
-    uint16 constant LONG_PROXY_IDX = 4;
-    uint16 constant MICRO_PROXY_IDX = 5;
+    uint16 constant LONG_PROXY_IDX = 130;
+    uint16 constant MICRO_PROXY_IDX = 131;
     uint16 constant MULTICALL_PROXY_IDX = 6;
     uint16 constant KNOCKOUT_LP_PROXY_IDX = 7;
     uint16 constant FLAG_CROSS_PROXY_IDX = 3500;
     uint16 constant SAFE_MODE_PROXY_PATH = 9999;
+
+    // Used as proxy contracts by previous deployments. These slots should not be re-used
+    // to preserve backwards compatibility.
+    uint16 constant LP_PROXY_LEGACY_IDX = 2;
+    uint16 constant LONG_PROXY_LEGACY_IDX = 4;
+    uint16 constant MICRO_PROXY_LEGACY_IDX = 5;
+
 }
 
 // Not used in production. Just used so we can easily check struct size in hardhat.

--- a/contracts/mixins/TradeMatcher.sol
+++ b/contracts/mixins/TradeMatcher.sol
@@ -128,12 +128,12 @@ contract TradeMatcher is PositionRegistrar, LiquidityCurve, KnockoutCounter,
                         int24 lowTick, int24 highTick, uint128 liquidity,
                         bytes32 poolHash, address lpOwner)
         internal returns (int128 baseFlow, int128 quoteFlow) {
-        uint64 feeMileage = addBookLiq(poolHash, priceTick, lowTick, highTick,
+        uint72 feeMileage = addBookLiq72(poolHash, priceTick, lowTick, highTick,
                                        liquidity.liquidityToLots(),
                                        curve.concGrowth_);
         
         mintPosLiq(lpOwner, poolHash, lowTick, highTick,
-                   liquidity, feeMileage);
+                     liquidity, feeMileage);
         depositConduit(poolHash, lowTick, highTick, liquidity, feeMileage, lpOwner);
 
         (uint128 base, uint128 quote) = liquidityReceivable
@@ -163,7 +163,7 @@ contract TradeMatcher is PositionRegistrar, LiquidityCurve, KnockoutCounter,
                         int24 lowTick, int24 highTick, uint128 liquidity,
                         bytes32 poolHash, address lpOwner)
         internal returns (int128, int128) {
-        uint64 feeMileage = removeBookLiq(poolHash, priceTick, lowTick, highTick,
+        uint72 feeMileage = removeBookLiq72(poolHash, priceTick, lowTick, highTick,
                                           liquidity.liquidityToLots(),
                                           curve.concGrowth_);
         uint64 rewards = burnPosLiq(lpOwner, poolHash, lowTick, highTick, liquidity,
@@ -177,7 +177,7 @@ contract TradeMatcher is PositionRegistrar, LiquidityCurve, KnockoutCounter,
 
     /* @notice Dispatches the call to the ICrocLpConduit with the ambient liquidity 
      *         LP position that was minted. */
-    function depositConduit (bytes32 poolHash, uint128 liqSeeds, uint64 deflator,
+    function depositConduit (bytes32 poolHash, uint128 liqSeeds, uint72 deflator,
                              address lpConduit) private {
         // Equivalent to calling concentrated liquidity deposit with lowTick=0 and highTick=0
         // Since a true range order can never have a width of zero, the receiving deposit
@@ -190,7 +190,7 @@ contract TradeMatcher is PositionRegistrar, LiquidityCurve, KnockoutCounter,
     /* @notice Dispatches the call to the ICrocLpConduit with the concentrated liquidity 
      *         LP position that was minted. */
     function depositConduit (bytes32 poolHash, int24 lowTick, int24 highTick,
-                             uint128 liq, uint64 mileage, address lpConduit) private {
+                             uint128 liq, uint72 mileage, address lpConduit) private {
         if (lpConduit != lockHolder_) {
             bool doesAccept = ICrocLpConduit(lpConduit).
                 depositCrocLiq(lockHolder_, poolHash, lowTick, highTick, liq, mileage);
@@ -200,7 +200,7 @@ contract TradeMatcher is PositionRegistrar, LiquidityCurve, KnockoutCounter,
 
     /* @notice Withdraws and sends ownership of the ambient liquidity to a third party conduit
      *         explicitly nominated by the caller. */
-    function withdrawConduit (bytes32 poolHash, uint128 liqSeeds, uint64 deflator,
+    function withdrawConduit (bytes32 poolHash, uint128 liqSeeds, uint72 deflator,
                               address lpConduit) private {
         withdrawConduit(poolHash, 0, 0, liqSeeds, deflator, lpConduit);
     }
@@ -208,7 +208,7 @@ contract TradeMatcher is PositionRegistrar, LiquidityCurve, KnockoutCounter,
     /* @notice Withdraws and sends ownership of the liquidity to a third party conduit
      *         explicitly nominated by the caller. */
     function withdrawConduit (bytes32 poolHash, int24 lowTick, int24 highTick,
-                              uint128 liq, uint64 mileage, address lpConduit) private {
+                              uint128 liq, uint72 mileage, address lpConduit) private {
         if (lpConduit != lockHolder_) {
             bool doesAccept = ICrocLpConduit(lpConduit).
                 withdrawCrocLiq(lockHolder_, poolHash, lowTick, highTick, liq, mileage);
@@ -322,8 +322,8 @@ contract TradeMatcher is PositionRegistrar, LiquidityCurve, KnockoutCounter,
                            int24 lowTick, int24 highTick, bytes32 poolHash,
                            address lpOwner)
         internal returns (int128, int128) {
-        uint64 feeMileage = clockFeeOdometer(poolHash, priceTick, lowTick, highTick,
-                                             curve.concGrowth_);
+        uint72 feeMileage = clockFeeOdometer72(poolHash, priceTick, lowTick, highTick,
+                                               curve.concGrowth_);
         uint128 rewards = harvestPosLiq(lpOwner, poolHash,
                                         lowTick, highTick, feeMileage);
         withdrawConduit(poolHash, lowTick, highTick, 0, feeMileage, lpOwner);

--- a/contracts/periphery/CrocLpErc20.sol
+++ b/contracts/periphery/CrocLpErc20.sol
@@ -30,7 +30,7 @@ contract CrocLpErc20 is ERC20, ICrocLpConduit {
     
     function depositCrocLiq (address sender, bytes32 pool,
                              int24 lowerTick, int24 upperTick, uint128 seeds,
-                             uint64) public override returns (bool) {
+                             uint72) public override returns (bool) {
         require(pool == poolHash, "Wrong pool");
         require(lowerTick == 0 && upperTick == 0, "Non-Ambient LP Deposit");
         _mint(sender, seeds);
@@ -39,7 +39,7 @@ contract CrocLpErc20 is ERC20, ICrocLpConduit {
 
     function withdrawCrocLiq (address sender, bytes32 pool,
                               int24 lowerTick, int24 upperTick, uint128 seeds,
-                              uint64) public override returns (bool) {
+                              uint72) public override returns (bool) {
         require(pool == poolHash, "Wrong pool");
         require(lowerTick == 0 && upperTick == 0, "Non-Ambient LP Deposit");
         _burn(sender, seeds);

--- a/contracts/test/MockConduit.sol
+++ b/contracts/test/MockConduit.sol
@@ -14,7 +14,7 @@ contract MockLpConduit is ICrocLpConduit {
     int24 public lowerSnap_;
     int24 public upperSnap_;
     uint128 public liqSnap_;
-    uint64 public mileageSnap_;
+    uint72 public mileageSnap_;
     bool public isDeposit_;
     
     constructor (bool accept) {
@@ -32,7 +32,7 @@ contract MockLpConduit is ICrocLpConduit {
 
     function depositCrocLiq (address sender, bytes32 poolHash,
                              int24 lowerTick, int24 upperTick, uint128 liq,
-                             uint64 mileage) public override returns (bool) {
+                             uint72 mileage) public override returns (bool) {
         isDeposit_ = true;
         senderSnap_ = sender;
         poolSnap_ = poolHash;
@@ -45,7 +45,7 @@ contract MockLpConduit is ICrocLpConduit {
 
     function withdrawCrocLiq (address sender, bytes32 poolHash,
                               int24 lowerTick, int24 upperTick, uint128 liq,
-                              uint64 mileage) public override returns (bool) {
+                              uint72 mileage) public override returns (bool) {
         isDeposit_ = false;
         senderSnap_ = sender;
         poolSnap_ = poolHash;

--- a/contracts/test/TestLevelBook.sol
+++ b/contracts/test/TestLevelBook.sol
@@ -45,3 +45,44 @@ contract TestLevelBook is LevelBook {
     }
 
 }
+
+contract TestLevelBook72Bit is LevelBook {
+    using TickMath for uint160;
+
+    int256 public liqDelta;
+    bool public knockoutFlag;
+    uint256 public odometer;
+
+    function getLevelState (uint256 poolIdx, int24 tick) public view returns
+        (BookLevel memory) {
+        return levelState(bytes32(poolIdx), tick);
+    }
+
+    function pullFeeOdometer (uint256 poolIdx, int24 mid, int24 bid, int24 ask,
+                              uint64 feeGlobal)
+        public view returns (uint72) {
+        return clockFeeOdometer72(bytes32(poolIdx), mid, bid, ask, feeGlobal);
+    }
+
+    function testCrossLevel (uint256 poolIdx, int24 tick, bool isBuy,
+                             uint64 feeGlobal) public {
+        (liqDelta, knockoutFlag) = crossLevel(bytes32(poolIdx), tick, isBuy, feeGlobal);
+    }
+
+    function testAdd (uint256 poolIdx, int24 midTick, int24 bidTick, int24 askTick,
+                      uint96 lots, uint64 globalFee) public {
+        odometer = addBookLiq72(bytes32(poolIdx), midTick, bidTick, askTick,
+                                lots, globalFee);
+    }
+
+    function testRemove (uint256 poolIdx, int24 midTick, int24 bidTick, int24 askTick,
+                         uint96 lots, uint64 globalFee) public {
+        odometer = removeBookLiq72(bytes32(poolIdx), midTick, bidTick, askTick,
+                                   lots, globalFee);
+    }
+
+    function hasTickBump (uint256 poolIdx, int24 tick) public view returns (bool) {
+        return hasTickBookmark(bytes32(poolIdx), tick);
+    }
+
+}

--- a/contracts/test/TestLiquidityMath.sol
+++ b/contracts/test/TestLiquidityMath.sol
@@ -17,4 +17,22 @@ contract TestLiquidityMath {
     function testMinus (uint128 x, uint128 y) public pure returns (uint128) {
         return x.minusDelta(y);
     }
+
+    function testDeltaRewards (uint64 x, uint64 y) public pure returns (uint64) {
+        return LiquidityMath.deltaRewardsRate(x, y);
+    }
+
+    function testDeltaRewards72 (uint72 x, uint72 y) public pure returns (uint64) {
+        return LiquidityMath.deltaRewardsRate72(x, y);
+    }
+
+    function testBlendMileage (uint64 mileageX, uint128 liqX, 
+        uint64 mileageY, uint128 liqY) public pure returns (uint64) {
+        return LiquidityMath.blendMileage(mileageX, liqX, mileageY, liqY);
+    }
+
+    function testBlendMileage72 (uint72 mileageX, uint128 liqX, 
+        uint72 mileageY, uint128 liqY) public pure returns (uint72) {
+        return LiquidityMath.blendMileage72(mileageX, liqX, mileageY, liqY);
+    }
 }

--- a/contracts/test/TestPositionRegistrar.sol
+++ b/contracts/test/TestPositionRegistrar.sol
@@ -21,7 +21,7 @@ contract TestPositionRegistrar is PositionRegistrar {
 
     function getPos (address owner, uint256 poolIdx, int24 lower, int24 upper)
         public view returns (uint128, uint256) {
-        RangePosition storage pos = lookupPosition(owner, bytes32(poolIdx),
+        RangePosition72 storage pos = lookupPosition(owner, bytes32(poolIdx),
                                                    lower, upper);
         return (pos.liquidity_, pos.feeMileage_);
     }

--- a/misc/constants/addrs.ts
+++ b/misc/constants/addrs.ts
@@ -169,10 +169,10 @@ export let POOL_IDXS = {
 
 export const BOOT_PROXY_IDX = 0;
 export const SWAP_PROXY_IDX = 1;
-export const LP_PROXY_IDX = 2;
+export const LP_PROXY_IDX = 128;
 export const COLD_PROXY_IDX = 3;
-export const LONG_PROXY_IDX = 4;
-export const MICRO_PROXY_IDX = 5;
+export const LONG_PROXY_IDX = 130;
+export const MICRO_PROXY_IDX = 131;
 export const KNOCKOUT_LP_PROXY_IDX = 7;
 export const FLAG_CROSS_PROXY_IDX = 3500;
 export const SAFE_MODE_PROXY_PATH = 9999;

--- a/test/FacadePool.ts
+++ b/test/FacadePool.ts
@@ -14,7 +14,7 @@ import { QueryHelper } from '../typechain/QueryHelper';
 import { TestSettleLayer } from "../typechain/TestSettleLayer";
 import { CrocQuery } from "../typechain/CrocQuery";
 import { BootPath } from "../contracts/typechain";
-import { buildCrocSwapSex } from "./SetupDex";
+import { BOOT_PROXY_IDX, COLD_PROXY_IDX, KNOCKOUT_LP_PROXY_IDX, LONG_PROXY_IDX, LP_PROXY_IDX, SAFE_MODE_PROXY_PATH, SWAP_PROXY_IDX, buildCrocSwapSex } from "./SetupDex";
 
 chai.use(solidity);
 
@@ -440,13 +440,13 @@ export class TestPool {
         return this.testSwapFrom(await this.other, isBuy, inBaseQty, qty, price)
     }
 
-    readonly BOOT_PROXY: number = 0;
-    readonly HOT_PROXY: number = 1;
-    readonly WARM_PROXY: number = 2;
-    readonly COLD_PROXY: number = 3;
-    readonly LONG_PROXY: number = 4;
-    readonly KNOCKOUT_PROXY: number = 7;
-    readonly EMERGENCY_PROXY: number = 9999
+    readonly BOOT_PROXY: number = BOOT_PROXY_IDX
+    readonly HOT_PROXY: number = SWAP_PROXY_IDX
+    readonly WARM_PROXY: number = LP_PROXY_IDX
+    readonly COLD_PROXY: number = COLD_PROXY_IDX
+    readonly LONG_PROXY: number = LONG_PROXY_IDX
+    readonly KNOCKOUT_PROXY: number = KNOCKOUT_LP_PROXY_IDX
+    readonly EMERGENCY_PROXY: number = SAFE_MODE_PROXY_PATH
 
     async testMintFrom (from: Signer, lower: number, upper: number, liq: number, useSurplus: number = 0): Promise<ContractTransaction> {
         await this.snapStart()

--- a/test/SetupDex.ts
+++ b/test/SetupDex.ts
@@ -7,10 +7,10 @@ import { AbiCoder } from "@ethersproject/abi";
 
 export const BOOT_PROXY_IDX = 0;
 export const SWAP_PROXY_IDX = 1;
-export const LP_PROXY_IDX = 2;
+export const LP_PROXY_IDX = 128;
 export const COLD_PROXY_IDX = 3;
-export const LONG_PROXY_IDX = 4;
-export const MICRO_PROXY_IDX = 5;
+export const LONG_PROXY_IDX =130;
+export const MICRO_PROXY_IDX = 131;
 export const KNOCKOUT_LP_PROXY_IDX = 7;
 export const FLAG_CROSS_PROXY_IDX = 3500;
 export const SAFE_MODE_PROXY_PATH = 9999;

--- a/test/TestGas.eth.ts
+++ b/test/TestGas.eth.ts
@@ -46,12 +46,12 @@ describe('Gas Benchmarks Native Eth', () => {
 
     it("mint increase liq [@gas-test]", async() => {
         await test.testMint(-100, 100, 100)
-        await expectGas(test.testMint(-100, 100, 10000), 106000)
+        await expectGas(test.testMint(-100, 100, 10000), 107000)
     })
 
     it("mint pre-init ticks [@gas-test]", async() => {
         await test.testMint(-100, 100, 100)
-        await expectGas(test.testMintOther(-100, 100, 10000), 123000)
+        await expectGas(test.testMintOther(-100, 100, 10000), 124000)
     })
 
     it("mint one fresh init [@gas-test]", async() => {
@@ -130,7 +130,7 @@ describe('Gas Benchmarks Native Eth', () => {
         await test.testMint(-100, 100, 100)
         await test.testMintOther(-100, 100, 1000)
         await test.testSwapOther(true, true, 1000000, toSqrtPrice(1.1))
-        await expectGas(test.testBurn(-100, 100, 100), 96000)
+        await expectGas(test.testBurn(-100, 100, 100), 97000)
     })
 
     it("harvest fees [@gas-test]", async() => {

--- a/test/TestLevelBook.ts
+++ b/test/TestLevelBook.ts
@@ -5,6 +5,7 @@ import { ethers } from 'hardhat';
 import { toFixedGrowth, fromFixedGrowth } from './FixedPoint';
 import { solidity } from "ethereum-waffle";
 import chai from "chai";
+import { TestLevelBook72Bit } from '../typechain';
 
 chai.use(solidity);
 
@@ -14,6 +15,373 @@ describe('LevelBook', () => {
    beforeEach("deploy", async () => {
       const factory = await ethers.getContractFactory("TestLevelBook");
       book = (await factory.deploy()) as TestLevelBook;
+   })
+
+    it("empty init", async() => {
+        let lvl = await book.getLevelState(0, 100);
+        expect(lvl.askLots_.toNumber()).to.equal(0);
+        expect(lvl.bidLots_.toNumber()).to.equal(0);
+        expect(lvl.feeOdometer_.toNumber()).to.equal(0);
+
+        lvl = await book.getLevelState(0, 100);
+        expect(lvl.askLots_.toNumber()).to.equal(0);
+        expect(lvl.bidLots_.toNumber()).to.equal(0);
+        expect(lvl.feeOdometer_.toNumber()).to.equal(0);
+    })
+
+    it("add fresh liq", async() => {
+        await book.testAdd(0, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        let bid = await book.getLevelState(0, 95);
+        let ask = await book.getLevelState(0, 105);
+        let mid = await book.getLevelState(0, 100);
+        let alt = await book.getLevelState(1, 95);
+        expect(bid.bidLots_.toNumber()).to.equal(10000);
+        expect(bid.askLots_.toNumber()).to.equal(0);
+        expect(ask.bidLots_.toNumber()).to.equal(0);
+        expect(ask.askLots_.toNumber()).to.equal(10000);
+        expect(mid.bidLots_.toNumber()).to.equal(0);
+        expect(mid.bidLots_.toNumber()).to.equal(0);
+        expect(alt.bidLots_.toNumber()).to.equal(0);
+        expect(alt.bidLots_.toNumber()).to.equal(0);
+    })
+
+    it("stack liq", async() => {
+        await book.testAdd(1, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        await book.testAdd(1, 100, 95, 110, 20000, toFixedGrowth(0.5))
+        await book.testAdd(1, 100, 90, 105, 33000, toFixedGrowth(0.5))
+        await book.testAdd(1, 100, 90, 95, 50000, toFixedGrowth(0.5))
+        let bid = await book.getLevelState(1, 95);
+        let ask = await book.getLevelState(1, 105);
+        expect(bid.bidLots_.toNumber()).to.equal(30000);
+        expect(bid.askLots_.toNumber()).to.equal(50000);
+        expect(ask.bidLots_.toNumber()).to.equal(0);
+        expect(ask.askLots_.toNumber()).to.equal(43000);
+    })
+
+    it("add above", async() => {
+        await book.testAdd(3, 50, 95, 105, 10000, toFixedGrowth(0.5))
+        let bid = await book.getLevelState(3, 95);
+        let ask = await book.getLevelState(3, 105);
+        expect(bid.bidLots_.toNumber()).to.equal(10000);
+        expect(bid.askLots_.toNumber()).to.equal(0);
+        expect(ask.bidLots_.toNumber()).to.equal(0);
+        expect(ask.askLots_.toNumber()).to.equal(10000);
+    })
+
+    it("add below", async() => {
+        await book.testAdd(0, 150, 95, 105, 10000, toFixedGrowth(0.5))
+        let bid = await book.getLevelState(0, 95);
+        let ask = await book.getLevelState(0, 105);
+        expect(bid.bidLots_.toNumber()).to.equal(10000);
+        expect(bid.askLots_.toNumber()).to.equal(0);
+        expect(ask.bidLots_.toNumber()).to.equal(0);
+        expect(ask.askLots_.toNumber()).to.equal(10000);
+    })
+
+    it("remove partial", async() => {
+        await book.testAdd(2, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        await book.testAdd(2, 100, 95, 110, 20000, toFixedGrowth(0.5))
+        await book.testRemove(2, 100, 95, 105, 3000, toFixedGrowth(0.5))
+        await book.testRemove(2, 100, 95, 110, 5000, toFixedGrowth(0.5))
+        let bid = await book.getLevelState(2, 95);
+        let ask = await book.getLevelState(2, 105);
+        let ask2 = await book.getLevelState(2, 110);
+        expect(bid.bidLots_.toNumber()).to.equal(22000);
+        expect(bid.askLots_.toNumber()).to.equal(0);
+        expect(ask.bidLots_.toNumber()).to.equal(0);
+        expect(ask.askLots_.toNumber()).to.equal(7000);
+        expect(ask2.askLots_.toNumber()).to.equal(15000);
+    })
+
+    it("remove full", async() => {
+        await book.testAdd(0, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        await book.testAdd(0, 100, 95, 110, 20000, toFixedGrowth(0.5))
+        await book.testRemove(0, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        let bid = await book.getLevelState(0, 95);
+        let ask = await book.getLevelState(0, 105);
+        expect(bid.bidLots_.toNumber()).to.equal(20000);
+        expect(bid.askLots_.toNumber()).to.equal(0);
+        expect(ask.bidLots_.toNumber()).to.equal(0);
+        expect(ask.askLots_.toNumber()).to.equal(0);
+    })
+
+    it("remove over", async() => {
+        await book.testAdd(2, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        await book.testAdd(2, 100, 95, 110, 20000, toFixedGrowth(0.5))
+        expect(book.testRemove(2, 100, 95, 105, 11000, toFixedGrowth(0.5))).to.be.reverted;
+    })
+    
+    it("bookmark ticks", async() => {
+        await book.testAdd(1, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        await book.testAdd(1, 100, 95, 110, 20000, toFixedGrowth(0.5))
+        await book.testAdd(1, 100, 90, 105, 33000, toFixedGrowth(0.5))
+        await book.testAdd(1, 100, 90, 95, 50000, toFixedGrowth(0.5))
+
+        expect(await book.hasTickBump(1, 90)).to.equal(true)
+        expect(await book.hasTickBump(1, 94)).to.equal(false)
+        expect(await book.hasTickBump(0, 95)).to.equal(false)
+        expect(await book.hasTickBump(1, 95)).to.equal(true)
+        expect(await book.hasTickBump(1, 100)).to.equal(false)
+        expect(await book.hasTickBump(1, 105)).to.equal(true)
+        expect(await book.hasTickBump(1, 110)).to.equal(true)
+        expect(await book.hasTickBump(2, 110)).to.equal(false)
+        expect(await book.hasTickBump(1, 500)).to.equal(false)
+    })
+
+    it("forget ticks", async() => {
+        await book.testAdd(3, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        await book.testAdd(3, 100, 95, 110, 20000, toFixedGrowth(0.5))
+        await book.testAdd(3, 100, 90, 105, 33000, toFixedGrowth(0.5))
+        await book.testAdd(3, 100, 90, 95, 50000, toFixedGrowth(0.5))
+        await book.testAdd(0, 100, 90, 110, 8000, toFixedGrowth(0.5))
+
+        await book.testRemove(3, 100, 95, 110, 12000, toFixedGrowth(0.5))
+        expect(await book.hasTickBump(3, 90)).to.equal(true)
+        expect(await book.hasTickBump(3, 95)).to.equal(true)
+        expect(await book.hasTickBump(3, 105)).to.equal(true)
+        expect(await book.hasTickBump(3, 110)).to.equal(true)
+        expect(await book.hasTickBump(0, 110)).to.equal(true)
+        
+        await book.testRemove(3, 100, 95, 110, 8000, toFixedGrowth(0.5))
+        expect(await book.hasTickBump(3, 90)).to.equal(true)
+        expect(await book.hasTickBump(3, 95)).to.equal(true)
+        expect(await book.hasTickBump(3, 105)).to.equal(true)
+        expect(await book.hasTickBump(3, 110)).to.equal(false)
+        expect(await book.hasTickBump(0, 110)).to.equal(true)
+
+        await book.testRemove(3, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        expect(await book.hasTickBump(3, 90)).to.equal(true)
+        expect(await book.hasTickBump(3, 95)).to.equal(true)
+        expect(await book.hasTickBump(3, 105)).to.equal(true)
+        expect(await book.hasTickBump(3, 110)).to.equal(false)
+        expect(await book.hasTickBump(0, 110)).to.equal(true)
+
+        await book.testRemove(3, 100, 90, 105, 33000, toFixedGrowth(0.5))
+        expect(await book.hasTickBump(3, 90)).to.equal(true)
+        expect(await book.hasTickBump(3, 95)).to.equal(true)
+        expect(await book.hasTickBump(3, 105)).to.equal(false)
+        expect(await book.hasTickBump(3, 110)).to.equal(false)
+        expect(await book.hasTickBump(0, 110)).to.equal(true)
+
+        await book.testRemove(3, 100, 90, 95, 50000, toFixedGrowth(0.5))
+        expect(await book.hasTickBump(3, 90)).to.equal(false)
+        expect(await book.hasTickBump(3, 95)).to.equal(false)
+        expect(await book.hasTickBump(3, 105)).to.equal(false)
+        expect(await book.hasTickBump(3, 110)).to.equal(false)
+        expect(await book.hasTickBump(0, 110)).to.equal(true)
+    })
+
+    it("cross level liq", async() => {
+        await book.testAdd(1, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        await book.testAdd(1, 100, 90, 95, 25000, toFixedGrowth(0.5))
+        await book.testAdd(2, 100, 90, 95, 35000, toFixedGrowth(0.8))
+        
+        await book.testCrossLevel(1, 95, true, toFixedGrowth(0.5))
+        expect((await book.liqDelta()).toNumber()).to.equal(-15000*1024)
+
+        await book.testCrossLevel(1, 95, false, toFixedGrowth(0.5))
+        expect((await book.liqDelta()).toNumber()).to.equal(15000*1024)
+        
+        await book.testCrossLevel(1, 90, false, toFixedGrowth(0.5))
+        expect((await book.liqDelta()).toNumber()).to.equal(-25000*1024)
+
+        await book.testCrossLevel(1, 90, true, toFixedGrowth(0.5))
+        expect((await book.liqDelta()).toNumber()).to.equal(25000*1024)
+
+        await book.testCrossLevel(1, 105, false, toFixedGrowth(0.5))
+        expect((await book.liqDelta()).toNumber()).to.equal(10000*1024)
+
+        await book.testCrossLevel(1, 106, false, toFixedGrowth(0.5))
+        expect((await book.liqDelta()).toNumber()).to.equal(0)
+
+        await book.testCrossLevel(2, 95, true, toFixedGrowth(0.8))
+        expect((await book.liqDelta()).toNumber()).to.equal(-35000*1024)
+    })
+
+    // Test that we can safely cross non-initialized levels without breaking the
+    // tick bitmap or screwing up liquidity.
+    it("cross non level", async() => {
+        await book.testAdd(1, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        await book.testAdd(1, 100, 90, 95, 25000, toFixedGrowth(0.5))
+        
+        await book.testCrossLevel(1, 98, false, toFixedGrowth(0.5))
+        expect((await book.liqDelta()).toNumber()).to.equal(0)
+        await book.testCrossLevel(1, 98, true, toFixedGrowth(0.5))
+        expect((await book.liqDelta()).toNumber()).to.equal(0)
+        expect(await book.hasTickBump(1, 98)).to.equal(false)
+
+        await book.testAdd(1, 100, 98, 102, 25000, toFixedGrowth(0.5))
+        expect(await book.hasTickBump(1, 98)).to.equal(true)
+        await book.testCrossLevel(1, 98, false, toFixedGrowth(0.5))
+        expect((await book.liqDelta()).toNumber()).to.equal(-25000*1024)        
+        await book.testCrossLevel(1, 98, true, toFixedGrowth(0.5))
+        expect((await book.liqDelta()).toNumber()).to.equal(25000*1024)        
+        expect(await book.hasTickBump(1, 98)).to.equal(true)
+
+        // Differnt pool
+        await book.testCrossLevel(0, 95, false, toFixedGrowth(0.5))
+        expect((await book.liqDelta()).toNumber()).to.equal(0)        
+    })
+
+    it("odometer add", async() => {
+        await book.testAdd(0, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        let start = await book.odometer()
+        await book.testAdd(0, 100, 95, 105, 10000, toFixedGrowth(0.75))
+        let end = await book.odometer()
+        expect(fromFixedGrowth(end.sub(start))).to.equal(0.25)
+    })
+
+    it("odometer remove partial", async() => {
+        await book.testAdd(1, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        let start = await book.odometer()
+        await book.testRemove(1, 100, 95, 105, 5000, toFixedGrowth(0.75))
+        let end = await book.odometer()
+        expect(fromFixedGrowth(end.sub(start))).to.equal(0.25)
+    })
+
+    it("odometer remove full", async() => {
+        await book.testAdd(2, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        let start = await book.odometer()
+        await book.testRemove(2, 100, 95, 105, 10000, toFixedGrowth(0.75))
+        let end = await book.odometer()
+        expect(fromFixedGrowth(end.sub(start))).to.equal(0.25)
+    })
+
+    it("odometer add/rmove sequence", async() => {
+        await book.testAdd(2, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        await book.testRemove(2, 100, 95, 105, 10000, toFixedGrowth(0.75))
+        await book.testAdd(2, 100, 95, 105, 10000, toFixedGrowth(1.25))
+        await book.testAdd(2, 100, 95, 105, 10000, toFixedGrowth(1.5))
+        await book.testRemove(2, 100, 95, 105, 10000, toFixedGrowth(1.75))
+        await book.testRemove(2, 100, 95, 105, 3000, toFixedGrowth(2.5))
+        let start = await book.odometer()
+        await book.testAdd(2, 100, 95, 105, 3000, toFixedGrowth(3.25))
+        let end = await book.odometer()
+        expect(fromFixedGrowth(end.sub(start))).to.equal(0.75)
+    })
+
+    it("above re-clock", async() => {
+        await book.testAdd(3, 110, 95, 105, 10000, toFixedGrowth(0.5))
+        let start = await book.odometer()
+        await book.testAdd(3, 110, 95, 105, 10000, toFixedGrowth(0.75))
+        let end = await book.odometer()
+        expect(fromFixedGrowth(end.sub(start))).to.equal(0)
+    })
+
+    it("odometer boundary", async() => {
+        await book.testAdd(4, 95, 95, 105, 10000, toFixedGrowth(0.5))
+        let start = await book.odometer()
+        await book.testAdd(4, 95, 95, 105, 10000, toFixedGrowth(0.75))
+        let end = await book.odometer()
+        expect(fromFixedGrowth(end.sub(start))).to.equal(0.25)
+
+        await book.testAdd(4, 105, 95, 105, 10000, toFixedGrowth(0.5))
+        start = await book.odometer()
+        await book.testAdd(4, 105, 95, 105, 10000, toFixedGrowth(0.75))
+        end = await book.odometer()
+        expect(fromFixedGrowth(end.sub(start))).to.equal(0)
+    })
+
+    // Levels may be initialized with zero global fee accumulation. It's tempting to use
+    // use zero odometer as an initialization condition, but this may not be the case for these
+    // levels. Verify that we don't erroneously re-initialize in these cases.
+    it("odometer zero init", async() => {
+        await book.testAdd(1, 100, 95, 105, 10000, toFixedGrowth(0))
+        let start = await book.odometer()
+        await book.testAdd(1, 100, 95, 105, 10000, toFixedGrowth(0.75))
+        let end = await book.odometer()        
+        expect(fromFixedGrowth(end.sub(start))).to.equal(0.75)
+    })
+
+    it("below re-clock", async() => {
+        await book.testAdd(2, 110, 95, 105, 10000, toFixedGrowth(0.5))
+        let start = await book.odometer()
+        await book.testAdd(2, 110, 95, 105, 10000, toFixedGrowth(0.75))
+        let end = await book.odometer()
+        expect(fromFixedGrowth(end.sub(start))).to.equal(0)
+    })
+
+    it("cross fee", async() => {
+        await book.testAdd(2, 100, 95, 105, 10000, toFixedGrowth(0.5))
+        let startOne = await book.odometer()
+        await book.testAdd(2, 100, 93, 98, 10000, toFixedGrowth(0.5))        
+        let startTwo = await book.odometer()
+        await book.testAdd(0, 100, 93, 98, 10000, toFixedGrowth(0.8))        
+        let startAlt = await book.odometer()
+
+        await book.testCrossLevel(2, 98, false, toFixedGrowth(0.75))
+        await book.testCrossLevel(2, 95, false, toFixedGrowth(1.0))
+        await book.testCrossLevel(0, 98, false, toFixedGrowth(1.25))
+
+        await book.testRemove(2, 94, 95, 105, 5000, toFixedGrowth(2.25))
+        let endOne = await book.odometer()
+        await book.testRemove(2, 94, 93, 98, 5000, toFixedGrowth(2.375))        
+        let endTwo = await book.odometer()
+        await book.testRemove(0, 94, 93, 98, 5000, toFixedGrowth(2.75))        
+        let endAlt = await book.odometer()
+
+        expect(fromFixedGrowth(endOne.sub(startOne))).to.equal(0.5)
+        expect(fromFixedGrowth(endTwo.sub(startTwo))).to.equal(1.625)
+        expect(fromFixedGrowth(endAlt.sub(startAlt))).to.equal(1.5)
+    })
+
+    it("cross up", async() => {
+        await book.testAdd(2, 94, 95, 105, 10000, toFixedGrowth(0.5))
+        let startOne = await book.odometer()
+        await book.testAdd(2, 94, 93, 98, 10000, toFixedGrowth(0.5))        
+        let startTwo = await book.odometer()
+
+        await book.testCrossLevel(2, 95, true, toFixedGrowth(0.75))
+        await book.testCrossLevel(2, 98, true, toFixedGrowth(1.25))
+        await book.testCrossLevel(2, 105, true, toFixedGrowth(2.25))
+
+        await book.testRemove(2, 105, 95, 105, 5000, toFixedGrowth(4.5))
+        let endOne = await book.odometer()
+        await book.testRemove(2, 105, 93, 98, 5000, toFixedGrowth(4.75))        
+        let endTwo = await book.odometer()
+
+        expect(fromFixedGrowth(endOne.sub(startOne))).to.equal(1.5)
+        expect(fromFixedGrowth(endTwo.sub(startTwo))).to.equal(0.75)
+    })
+
+    it("cross sequence", async() => {
+        await book.testAdd(2, 98, 95, 105, 10000, toFixedGrowth(0.5))
+        let start = await book.odometer()
+
+        await book.testCrossLevel(2, 95, false, toFixedGrowth(0.75))
+        await book.testCrossLevel(2, 95, true, toFixedGrowth(1.25))
+        await book.testRemove(2, 100, 95, 105, 1000, toFixedGrowth(1.5))
+        let end = await book.odometer()
+        expect(fromFixedGrowth(end.sub(start))).to.equal(0.25 + 0.25)
+        
+        await book.testCrossLevel(2, 105, true, toFixedGrowth(2.0))
+        await book.testCrossLevel(2, 105, false, toFixedGrowth(3.25))
+        await book.testRemove(2, 100, 95, 105, 1000, toFixedGrowth(3.5))
+        end = await book.odometer()
+        expect(fromFixedGrowth(end.sub(start))).to.equal(0.25 + 0.25 + 0.75)
+
+        await book.testCrossLevel(2, 95, false, toFixedGrowth(5.75))
+        await book.testCrossLevel(2, 95, true, toFixedGrowth(6.75))
+        await book.testRemove(2, 100, 95, 105, 1000, toFixedGrowth(8.25))
+        end = await book.odometer()
+        expect(fromFixedGrowth(end.sub(start))).to.equal(1.5 + 0.25 + 0.75 + 2.5)
+        
+        await book.testCrossLevel(2, 105, true, toFixedGrowth(16.5))
+        await book.testCrossLevel(2, 105, false, toFixedGrowth(17.5))
+        await book.testCrossLevel(2, 105, true, toFixedGrowth(28.75))
+
+        await book.testRemove(2, 107, 95, 105, 5000, toFixedGrowth(48.5))
+        end = await book.odometer()
+        expect(fromFixedGrowth(end.sub(start))).to.equal(3.5 + + 9.75 + 11.25)        
+    })
+})
+
+describe('LevelBook 72 bit', () => {
+    let book: TestLevelBook72Bit
+
+   beforeEach("deploy", async () => {
+      const factory = await ethers.getContractFactory("TestLevelBook72Bit");
+      book = (await factory.deploy()) as TestLevelBook72Bit;
    })
 
     it("empty init", async() => {

--- a/test/TestLiquidityMath.ts
+++ b/test/TestLiquidityMath.ts
@@ -5,6 +5,7 @@ import "@nomiclabs/hardhat-ethers";
 import { ethers } from 'hardhat';
 import { solidity } from "ethereum-waffle";
 import { toFixedGrowth } from './FixedPoint';
+import { BigNumber } from 'ethers';
 
 chai.use(solidity);
 
@@ -38,6 +39,130 @@ describe('LiquidityMath', () => {
       expect(liq.testMinus(100, 101)).to.be.reverted;
    })
 
+   const DELTA_OFFSET = 2
 
+   it("delta rewards", async() => {
+      let result = await liq.testDeltaRewards(5000, 4000)
+      expect(await result.toNumber()).to.eq(1000 - DELTA_OFFSET)
 
+      let bigMileage = BigNumber.from(2).pow(64).sub(50000)
+      result = await liq.testDeltaRewards(bigMileage, 50000)
+      expect(await result).to.eq(bigMileage.sub(50000 + DELTA_OFFSET))
+
+      result = await liq.testDeltaRewards(bigMileage, bigMileage.sub(50000))
+      expect(await result).to.eq(50000 - DELTA_OFFSET)
+   })
+
+   it("delta rewards oversize", async() => {
+      // Negative deltas cast to zero and don't overflow
+      let bigMileage = BigNumber.from(2).pow(64).sub(50000)
+      let result = await liq.testDeltaRewards(50000, bigMileage)
+      expect(await result).to.eq(0)
+
+      // Below the round down offset casts to 0
+      result = await liq.testDeltaRewards(10000, 10000)
+      expect(await result).to.eq(0)
+
+      result = await liq.testDeltaRewards(10001, 10000)
+      expect(await result).to.eq(0)
+
+      result = await liq.testDeltaRewards(10002, 10000)
+      expect(await result).to.eq(0)
+
+      result = await liq.testDeltaRewards(10003, 10000)
+      expect(await result).to.eq(1)
+   })
+
+   it("delta rewards 72-bit", async() => {
+      let result = await liq.testDeltaRewards72(5000, 4000)
+      expect(await result.toNumber()).to.eq(1000 - DELTA_OFFSET)
+
+      let bigMileage = BigNumber.from(2).pow(64).add(50000)
+      result = await liq.testDeltaRewards72(bigMileage, 50000)
+      expect(await result).to.eq(bigMileage.sub(50000 + DELTA_OFFSET))
+
+      result = await liq.testDeltaRewards72(bigMileage, bigMileage.sub(50000))
+      expect(await result).to.eq(50000 - DELTA_OFFSET)
+   })
+
+   it("delta rewards 72-bit oversize", async() => {
+      // Negative deltas cast to zero and don't overflow
+      let bigMileage = BigNumber.from(2).pow(64).add(50000)
+      let result = await liq.testDeltaRewards72(50000, bigMileage)
+      expect(await result).to.eq(0)
+
+      // Below the round down offset casts to 0
+      result = await liq.testDeltaRewards72(10000, 10000)
+      expect(await result).to.eq(0)
+
+      result = await liq.testDeltaRewards72(10001, 10000)
+      expect(await result).to.eq(0)
+
+      result = await liq.testDeltaRewards72(10002, 10000)
+      expect(await result).to.eq(0)
+
+      result = await liq.testDeltaRewards72(10003, 10000)
+      expect(await result).to.eq(1)
+
+      // Gap over uint64 max
+      let maxMileage64Bit = BigNumber.from(2).pow(64).sub(1)
+      result = await liq.testDeltaRewards72(bigMileage, 0)
+      expect(await result).to.eq(maxMileage64Bit)
+   })
+
+   it("blend mileage", async() => {
+      let blended = await liq.testBlendMileage(1000, 75, 2000, 25)
+      expect(blended).to.eq(1250 + DELTA_OFFSET)
+
+      // No blending needed because 0 weight on one side
+      blended = await liq.testBlendMileage(1000, 0, 2000, 25)
+      expect(blended).to.eq(2000)
+      blended = await liq.testBlendMileage(1000, 150, 2000, 0)
+      expect(blended).to.eq(1000)
+
+      // No blending (and round up) because equal mileage
+      blended = await liq.testBlendMileage(2000, 150, 2000, 200)
+      expect(blended).to.eq(2000)
+
+      // Make sure very mileage blends correctly
+      let bigOffset = BigNumber.from(2).pow(64).sub(3000)
+      blended = await liq.testBlendMileage(bigOffset.add(1000), 75, bigOffset.add(2000), 25)
+      expect(blended).to.eq(bigOffset.add(1250 + DELTA_OFFSET))
+
+      // Make sure we can handle weights at end of uint128
+      let hugeWeight = BigNumber.from(2).pow(127)
+      blended = await liq.testBlendMileage(1000, hugeWeight, 2000, hugeWeight.div(2))
+      expect(blended).to.eq(1332 + DELTA_OFFSET)
+
+      blended = await liq.testBlendMileage(bigOffset.add(1000), hugeWeight, bigOffset.add(2000), hugeWeight.div(2))
+      expect(blended).to.eq(bigOffset.add(1333 + DELTA_OFFSET))
+   })
+
+   it("blend mileage 72 bit", async() => {
+      let blended = await liq.testBlendMileage72(1000, 75, 2000, 25)
+      expect(blended).to.eq(1250 + DELTA_OFFSET)
+
+      // No blending needed because 0 weight on one side
+      blended = await liq.testBlendMileage72(1000, 0, 2000, 25)
+      expect(blended).to.eq(2000)
+      blended = await liq.testBlendMileage72(1000, 150, 2000, 0)
+      expect(blended).to.eq(1000)
+
+      // No blending (and round up) because equal mileage
+      blended = await liq.testBlendMileage72(2000, 150, 2000, 200)
+      expect(blended).to.eq(2000)
+
+      // Make sure very mileage blends correctly
+      let bigOffset = BigNumber.from(2).pow(70).sub(3000)
+      blended = await liq.testBlendMileage72(bigOffset.add(1000), 75, bigOffset.add(2000), 25)
+      expect(blended).to.eq(bigOffset.add(1250 + DELTA_OFFSET))
+
+      // Make sure we can handle weights at end of uint128
+      let hugeWeight = BigNumber.from(2).pow(127)
+      blended = await liq.testBlendMileage72(1000, hugeWeight, 2000, hugeWeight.div(2))
+      expect(blended).to.eq(1332 + DELTA_OFFSET)
+
+      blended = await liq.testBlendMileage72(bigOffset.add(1000), hugeWeight, bigOffset.add(2000), hugeWeight.div(2))
+      expect(blended).to.eq(bigOffset.add(1333 + DELTA_OFFSET))
+   })
 })

--- a/test/TestPool.conduit.ts
+++ b/test/TestPool.conduit.ts
@@ -7,7 +7,7 @@ import { solidity } from "ethereum-waffle";
 import chai from "chai";
 import { MockERC20 } from '../typechain/MockERC20';
 import { MockLpConduit } from '../typechain/MockLpConduit';
-import { ContractFactory } from 'ethers';
+import { BigNumber, ContractFactory } from 'ethers';
 
 chai.use(solidity);
 
@@ -35,6 +35,8 @@ describe('Pool Conduit', () => {
     })
 
     const MINT_BUFFER = 4;
+
+    const CONC_ZERO_MILEAGE = BigNumber.from(2).pow(64).sub(1)
 
     it("mint ambient", async() => {
         await test.testMintAmbient(5000)
@@ -74,7 +76,7 @@ describe('Pool Conduit', () => {
         expect(await conduit.lowerSnap_()).to.eq(-25000)
         expect(await conduit.upperSnap_()).to.eq(85000)
         expect(await conduit.liqSnap_()).to.eq(5000*1024)
-        expect(await conduit.mileageSnap_()).to.eq(0)
+        expect(await conduit.mileageSnap_()).to.eq(CONC_ZERO_MILEAGE)
     })
 
     it("burn concentrated", async() => {
@@ -85,7 +87,7 @@ describe('Pool Conduit', () => {
         expect(await conduit.lowerSnap_()).to.eq(-25000)
         expect(await conduit.upperSnap_()).to.eq(85000)
         expect(await conduit.liqSnap_()).to.eq(2000*1024)
-        expect(await conduit.mileageSnap_()).to.eq(0)
+        expect(await conduit.mileageSnap_()).to.eq(CONC_ZERO_MILEAGE)
     })
 
     it("mint concentrated deflator", async() => {
@@ -94,7 +96,7 @@ describe('Pool Conduit', () => {
         await test.testSwap(false, true, 2500000, MIN_PRICE)
         await test.testMint(-25000, 85000, 5000)
 
-        let mileage = (await conduit.mileageSnap_()).toNumber() / (2 ** 48)
+        let mileage = (await conduit.mileageSnap_()).sub(CONC_ZERO_MILEAGE).toNumber() / (2 ** 48)
         expect(mileage).to.lt(0.01)
         expect(mileage).to.gt(0.005)
         expect(await conduit.liqSnap_()).to.eq(5000*1024)

--- a/test/TestPool.rewards.ts
+++ b/test/TestPool.rewards.ts
@@ -1,0 +1,201 @@
+import { TestPool, makeTokenPool, Token } from './FacadePool'
+import { expect } from "chai";
+import "@nomiclabs/hardhat-ethers";
+import { ethers } from 'hardhat';
+import { toSqrtPrice, fromSqrtPrice, maxSqrtPrice, minSqrtPrice } from './FixedPoint';
+import { solidity } from "ethereum-waffle";
+import chai from "chai";
+import { MockERC20 } from '../typechain/MockERC20';
+
+chai.use(solidity);
+
+// Just a copy of the pool unit tests, but with hot path enabled
+describe('Pool LP Rewards', () => {
+    let test: TestPool
+    let baseToken: Token
+    let quoteToken: Token
+    const feeRate = 225 * 100
+
+    beforeEach("deploy",  async () => {
+       test = await makeTokenPool()
+       baseToken = await test.base
+       quoteToken = await test.quote
+
+       await test.initPool(feeRate, 0, 1, 1.5)
+       test.useHotPath = true
+       test.liqQty = true
+    })
+
+    async function accumFees (nRounds = 5) {
+        for (let i = 0; i < nRounds; ++i) {
+            await test.testSwap(true, false, 100000000, toSqrtPrice(2.0))
+            await test.testSwap(false, false, 100000000, toSqrtPrice(1.0))
+        }
+
+        await test.testSwap(true, false, 100000000, toSqrtPrice(1.5))
+    }
+
+    async function preWarmCurve() {
+        await test.testMintAmbient(1000)
+        await test.testMint(-25000, 25000, 1000)
+
+        await accumFees(1)
+    }
+
+    it("rewards growth", async() => {
+        await preWarmCurve()
+
+        await test.testMint(0, 10000, 1000)
+        await accumFees()
+        await test.testHarvest(0, 10000)
+
+        let baseFlow = await test.snapBaseOwed()
+        let quoteFlow = await test.snapQuoteOwed()
+        expect(baseFlow).to.eq(-221780)
+        expect(quoteFlow).to.eq(-147853)
+    })
+
+    it("rewards blend mint", async() => {
+        await preWarmCurve()
+
+        await test.testMint(0, 10000, 1000)
+        await accumFees()
+        await test.testMint(0, 10000, 2000)
+        await test.testHarvest(0, 10000)
+
+        let baseFlow = await test.snapBaseOwed()
+        let quoteFlow = await test.snapQuoteOwed()
+        expect(baseFlow).to.eq(-221780)
+        expect(quoteFlow).to.eq(-147853)
+    })
+
+    it("rewards pro rata burn", async() => {
+        await preWarmCurve()
+
+        await test.testMint(0, 10000, 1000)
+        await accumFees()
+        await test.testMint(0, 10000, 2000)
+        await test.testBurn(0, 10000, 2000)
+        await test.testHarvest(0, 10000)
+
+        let baseFlow = await test.snapBaseOwed()
+        let quoteFlow = await test.snapQuoteOwed()
+        expect(baseFlow).to.eq(-73881)
+        expect(quoteFlow).to.eq(-49254)
+    })
+
+    it("rewards growth zero curve", async() => {
+        await test.testMintAmbient(1000)
+        await test.testMint(-25000, 25000, 1000)
+
+        await test.testMint(0, 10000, 1000)
+        await accumFees()
+        await test.testHarvest(0, 10000)
+
+        let baseFlow = await test.snapBaseOwed()
+        let quoteFlow = await test.snapQuoteOwed()
+        expect(baseFlow).to.eq(-221780)
+        expect(quoteFlow).to.eq(-147853)
+    })
+
+    it("harvest resets", async() => {
+        await preWarmCurve()
+
+        await test.testMint(0, 10000, 1000)
+        await accumFees()
+        await test.testHarvest(0, 10000)
+        await test.testHarvest(0, 10000)
+
+        let baseFlow = await test.snapBaseOwed()
+        let quoteFlow = await test.snapQuoteOwed()
+        expect(baseFlow).to.eq(0)
+        expect(quoteFlow).to.eq(0)
+
+        await accumFees()
+        await test.testHarvest(0, 10000)
+        baseFlow = await test.snapBaseOwed()
+        quoteFlow = await test.snapQuoteOwed()
+        expect(baseFlow).to.eq(-221779)
+        expect(quoteFlow).to.eq(-147852)
+    })
+
+    it("no rewards below range", async() => {
+        await preWarmCurve()
+
+        await test.testMint(-1000, -100, 1)
+        await accumFees()
+        await test.testHarvest(-1000, -100)
+
+        let baseFlow = await test.snapBaseOwed()
+        let quoteFlow = await test.snapQuoteOwed()
+        expect(baseFlow).to.eq(0)
+        expect(quoteFlow).to.eq(0)
+    })
+
+    it("no rewards above range", async() => {
+        await preWarmCurve()
+
+        await test.testMint(-1000, -100, 1)
+        await accumFees()
+        await test.testHarvest(100000, 110000)
+
+        let baseFlow = await test.snapBaseOwed()
+        let quoteFlow = await test.snapQuoteOwed()
+        expect(baseFlow).to.eq(0)
+        expect(quoteFlow).to.eq(0)
+    })
+
+    it("on curve tick upper", async() => {
+        await preWarmCurve()
+
+        await test.testMint(-1000, 4054, 1)
+        await accumFees()
+        await test.testHarvest(-1000, 4054)
+
+        let baseFlow = await test.snapBaseOwed()
+        let quoteFlow = await test.snapQuoteOwed()
+        expect(baseFlow).to.lt(0)
+        expect(quoteFlow).to.lt(0)
+    })
+
+    it("on curve tick lower", async() => {
+        await preWarmCurve()
+
+        await test.testMint(4054, 10000, 1)
+        await accumFees()
+        await test.testHarvest(4054, 10000)
+
+        let baseFlow = await test.snapBaseOwed()
+        let quoteFlow = await test.snapQuoteOwed()
+        expect(baseFlow).to.lt(0)
+        expect(quoteFlow).to.lt(0)
+    })
+
+
+    it("rewards pre-init lower tick", async() => {
+        await preWarmCurve()
+
+        await test.testMint(-25000, 10000, 1000)
+        await accumFees()
+        await test.testHarvest(-25000, 10000)
+
+        let baseFlow = await test.snapBaseOwed()
+        let quoteFlow = await test.snapQuoteOwed()
+        expect(baseFlow).to.lt(0)
+        expect(quoteFlow).to.lt(0)
+    })
+
+    it("rewards pre-init upper tick", async() => {
+        await preWarmCurve()
+
+        await test.testMint(0, 25000, 1000)
+        await accumFees()
+        await test.testHarvest(0, 25000)
+
+        let baseFlow = await test.snapBaseOwed()
+        let quoteFlow = await test.snapQuoteOwed()
+        expect(baseFlow).to.lt(0)
+        expect(quoteFlow).to.lt(0)
+    })
+
+})

--- a/test/TestPositionRegistrar.ts
+++ b/test/TestPositionRegistrar.ts
@@ -57,7 +57,7 @@ describe('PositionRegistrar', () => {
         let result = await reg.getPos(owner, 0, -100, 100);
         expect(result[0].toNumber()).to.equal(450000);
         expect(result[1].toNumber()).to.gt(mileageMean);
-        expect(result[1].toNumber()).to.lte(mileageMean + 1);
+        expect(result[1].toNumber()).to.lte(mileageMean + 2);
     })
 
     it("add multi pos", async() => {


### PR DESCRIPTION
Inserts new versions of proxy contracts for WarmPath, LongPath and MicroPaths where all LP positions use a RangePosition struct and arithmetic calculation where starting and ending tick range rewards accumulator are represented as 72-bit unsigned integers with 2^64 fixed offsets. This eliminates the possibility of underflow in the LP rewards calculation.