### PR TITLE
feat: Add events

### DIFF
--- a/contracts/callpaths/ColdPath.sol
+++ b/contracts/callpaths/ColdPath.sol
@@ -33,8 +33,12 @@ contract ColdPath is MarketSequencer, DepositDesk, ProtocolAccount {
     using Chaining for Chaining.PairFlow;
     using ProtocolCmd for bytes;
 
+    event CrocColdCmd(bytes);
+    event CrocColdProtocolCmd(bytes);
+
     /* @notice Consolidated method for protocol control related commands. */
     function protocolCmd (bytes calldata cmd) virtual public {
+        emit CrocColdProtocolCmd(cmd);
         uint8 code = uint8(cmd[31]);
 
         if (code == ProtocolCmd.DISABLE_TEMPLATE_CODE) {
@@ -80,6 +84,7 @@ contract ColdPath is MarketSequencer, DepositDesk, ProtocolAccount {
     }
     
     function userCmd (bytes calldata cmd) virtual public payable {
+        emit CrocColdCmd(cmd);
         uint8 cmdCode = uint8(cmd[31]);
         
         if (cmdCode == UserCmd.INIT_POOL_CODE) {

--- a/contracts/callpaths/HotPath.sol
+++ b/contracts/callpaths/HotPath.sol
@@ -29,6 +29,7 @@ contract HotPath is MarketSequencer, SettleLayer, ProtocolAccount {
     using CurveMath for CurveMath.CurveState;
     using Chaining for Chaining.PairFlow;
 
+    event CrocSwap(address indexed base, address indexed quote,uint256,bool,bool,uint128,uint16,uint128,uint128,uint8,int128,int128);
 
     /* @notice Executes a swap on an arbitrary pool. */
     function swapExecute (address base, address quote,
@@ -46,6 +47,7 @@ contract HotPath is MarketSequencer, SettleLayer, ProtocolAccount {
         pivotOutFlow(flow, minOutput, isBuy, inBaseQty);        
         settleFlows(base, quote, flow.baseFlow_, flow.quoteFlow_, reserveFlags);
         accumProtocolFees(flow, base, quote);
+        emit CrocSwap(base, quote, poolIdx, isBuy, inBaseQty, qty, poolTip, limitPrice, minOutput, reserveFlags, baseFlow, quoteFlow);
     }
 
     /* @notice Final check at swap completion to verify that the non-fixed side of the 

--- a/contracts/callpaths/LiquidityMiningPath.sol
+++ b/contracts/callpaths/LiquidityMiningPath.sol
@@ -21,6 +21,10 @@ import "../libraries/ProtocolCmd.sol";
  *      fail on any. Because of this, this contract should never be used in any other
  *      context besides a proxy sidecar to CrocSwapDex. */
 contract LiquidityMiningPath is LiquidityMining {
+
+    event ClaimConcentratedRewards(address indexed user, bytes32 indexed poolIdx, int24, int24, uint32[]);
+    event SetConcentratedRewards(bytes32 indexed poolIdx, uint32, uint32, uint64);
+
     /* @notice Consolidated method for protocol control related commands. 
      *         Used to set reward rates */
     function protocolCmd(bytes calldata cmd) public virtual {
@@ -55,10 +59,12 @@ contract LiquidityMiningPath is LiquidityMining {
         public
         payable
     {
+        emit ClaimConcentratedRewards(msg.sender, poolIdx, lowerTick, upperTick, weeksToClaim);
         claimConcentratedRewards(payable(msg.sender), poolIdx, lowerTick, upperTick, weeksToClaim);
     }
 
     function setConcRewards(bytes32 poolIdx, uint32 weekFrom, uint32 weekTo, uint64 weeklyReward) public payable {
+        emit SetConcentratedRewards(poolIdx, weekFrom, weekTo, weeklyReward);
         // require(msg.sender == governance_, "Only callable by governance");
         require(weekFrom % WEEK == 0 && weekTo % WEEK == 0, "Invalid weeks");
         while (weekFrom <= weekTo) {

--- a/contracts/callpaths/WarmPath.sol
+++ b/contracts/callpaths/WarmPath.sol
@@ -37,6 +37,8 @@ contract WarmPath is MarketSequencer, SettleLayer, ProtocolAccount {
     using CurveMath for CurveMath.CurveState;
     using Chaining for Chaining.PairFlow;
 
+    event CrocWarmCmd(bytes,int128,int128);
+
     /* @notice Consolidated method for all atomic liquidity provider actions.
      * @dev    We consolidate multiple call types into a single method to reduce the 
      *         contract size in the main contract by paring down methods.
@@ -58,6 +60,7 @@ contract WarmPath is MarketSequencer, SettleLayer, ProtocolAccount {
             commitLP(code, base, quote, poolIdx, bidTick, askTick,
                      liq, limitLower, limitHigher, lpConduit);
         settleFlows(base, quote, baseFlow, quoteFlow, reserveFlags);
+        emit CrocWarmCmd(input, baseFlow, quoteFlow);
     }
 
     


### PR DESCRIPTION
- add events to dex
- canto needs events because subgraph must use events, cannot use calls w/o parity node